### PR TITLE
feat: Checking if DOCKER_API_VERSION is set, if not set it to 1.44, i…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,6 +122,17 @@ func PreRun(cmd *cobra.Command, _ []string) {
 		log.Warn("Using `WATCHTOWER_NO_PULL` and `WATCHTOWER_MONITOR_ONLY` simultaneously might lead to no action being taken at all. If this is intentional, you may safely ignore this message.")
 	}
 
+	// check if DOCKER_API_VERSION is set
+	if os.Getenv("DOCKER_API_VERSION") == "" {
+		log.Warn("The DOCKER_API_VERSION environment variable is not set. This may cause unexpected behavior while recreating docker containers. Defaulting to 1.44")
+		// set DOCKER_API_VERSION to 1.44
+		os.Setenv("DOCKER_API_VERSION", "1.44")
+	}
+	// check if DOCKER_API_VERSION is set to minimum 1.44 or higher
+	if os.Getenv("DOCKER_API_VERSION") < "1.44" {
+		log.Warn("The DOCKER_API_VERSION environment variable is set to a version lower than 1.44. This may cause unexpected behavior while recreating docker containers.")
+	}
+
 	client = container.NewClient(container.ClientOptions{
 		IncludeStopped:    includeStopped,
 		ReviveStopped:     reviveStopped,


### PR DESCRIPTION
…f its lower then 1.44 log warning

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
