### PR TITLE
fix: increase default DOCKER_API_VERSION to 1.44

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,17 +122,6 @@ func PreRun(cmd *cobra.Command, _ []string) {
 		log.Warn("Using `WATCHTOWER_NO_PULL` and `WATCHTOWER_MONITOR_ONLY` simultaneously might lead to no action being taken at all. If this is intentional, you may safely ignore this message.")
 	}
 
-	// check if DOCKER_API_VERSION is set
-	if os.Getenv("DOCKER_API_VERSION") == "" {
-		log.Warn("The DOCKER_API_VERSION environment variable is not set. This may cause unexpected behavior while recreating docker containers. Defaulting to 1.44")
-		// set DOCKER_API_VERSION to 1.44
-		os.Setenv("DOCKER_API_VERSION", "1.44")
-	}
-	// check if DOCKER_API_VERSION is set to minimum 1.44 or higher
-	if os.Getenv("DOCKER_API_VERSION") < "1.44" {
-		log.Warn("The DOCKER_API_VERSION environment variable is set to a version lower than 1.44. This may cause unexpected behavior while recreating docker containers.")
-	}
-
 	client = container.NewClient(container.ClientOptions{
 		IncludeStopped:    includeStopped,
 		ReviveStopped:     reviveStopped,

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -172,7 +172,7 @@ The API version to use by the Docker client for connecting to the Docker daemon.
             Argument: --api-version, -a
 Environment Variable: DOCKER_API_VERSION
                 Type: String
-             Default: "1.24"
+             Default: "1.44"
 ```
 
 ## Include restarting

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -17,7 +17,7 @@ import (
 
 // DockerAPIMinVersion is the minimum version of the docker api required to
 // use watchtower
-const DockerAPIMinVersion string = "1.25"
+const DockerAPIMinVersion string = "1.44"
 
 var defaultInterval = int((time.Hour * 24).Seconds())
 


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
