### PR TITLE
feat: add flag to disable to the memory swappiness

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,17 +117,19 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	reviveStopped, _ := f.GetBool("revive-stopped")
 	removeVolumes, _ := f.GetBool("remove-volumes")
 	warnOnHeadPullFailed, _ := f.GetString("warn-on-head-failure")
+	disableMemorySwappiness, _ := f.GetBool("disable-memory-swappiness")
 
 	if monitorOnly && noPull {
 		log.Warn("Using `WATCHTOWER_NO_PULL` and `WATCHTOWER_MONITOR_ONLY` simultaneously might lead to no action being taken at all. If this is intentional, you may safely ignore this message.")
 	}
 
 	client = container.NewClient(container.ClientOptions{
-		IncludeStopped:    includeStopped,
-		ReviveStopped:     reviveStopped,
-		RemoveVolumes:     removeVolumes,
-		IncludeRestarting: includeRestarting,
-		WarnOnHeadFailed:  container.WarningStrategy(warnOnHeadPullFailed),
+		IncludeStopped:          includeStopped,
+		ReviveStopped:           reviveStopped,
+		RemoveVolumes:           removeVolumes,
+		IncludeRestarting:       includeRestarting,
+		DisableMemorySwappiness: disableMemorySwappiness,
+		WarnOnHeadFailed:        container.WarningStrategy(warnOnHeadPullFailed),
 	})
 
 	notifier = notifications.NewNotifier(cmd)

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -498,3 +498,15 @@ Environment Variable: WATCHTOWER_PORCELAIN
      Possible values: v1
              Default: -
 ```
+
+## Compatibility with podman (Disable memory swappiness)
+
+Disable memory swappiness. By default, podman sets the memory-swappiness value to 0 when no memory-swappiness is defined
+When this flag is specified, watchtower will set the memory-swappiness to nil, fixing a compatibility issue with podman running with crun and cgroupv2
+
+```text
+            Argument: --disable-memory-swappiness
+Environment Variable: WATCHTOWER_DISABLE_MEMORY_SWAPPINESS
+                Type: Boolean
+             Default: false
+```

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -211,6 +211,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		envBool("WATCHTOWER_LABEL_TAKE_PRECEDENCE"),
 		"Label applied to containers take precedence over arguments")
+
+	flags.BoolP(
+		"disable-memory-swappiness",
+		"",
+		envBool("WATCHTOWER_DISABLE_MEMORY_SWAPPINESS"),
+		"Label used for setting memory swappiness as nil when recreating the container, used for compatibility with podman")
 }
 
 // RegisterNotificationFlags that are used by watchtower to send notifications
@@ -437,6 +443,7 @@ func SetDefaults() {
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER", "watchtower")
 	viper.SetDefault("WATCHTOWER_LOG_LEVEL", "info")
 	viper.SetDefault("WATCHTOWER_LOG_FORMAT", "auto")
+	viper.SetDefault("WATCHTOWER_DISABLE_MEMORY_SWAPPINESS", false)
 }
 
 // EnvConfig translates the command-line options into environment variables

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -57,11 +57,12 @@ func NewClient(opts ClientOptions) Client {
 
 // ClientOptions contains the options for how the docker client wrapper should behave
 type ClientOptions struct {
-	RemoveVolumes     bool
-	IncludeStopped    bool
-	ReviveStopped     bool
-	IncludeRestarting bool
-	WarnOnHeadFailed  WarningStrategy
+	RemoveVolumes           bool
+	IncludeStopped          bool
+	ReviveStopped           bool
+	IncludeRestarting       bool
+	DisableMemorySwappiness bool
+	WarnOnHeadFailed        WarningStrategy
 }
 
 // WarningStrategy is a value determining when to show warnings
@@ -250,6 +251,11 @@ func (client dockerClient) StartContainer(c t.Container) (t.ContainerID, error) 
 	config := c.GetCreateConfig()
 	hostConfig := c.GetCreateHostConfig()
 	networkConfig := client.GetNetworkConfig(c)
+
+	// this is a flag set for podman compatibility
+	if client.DisableMemorySwappiness {
+		hostConfig.MemorySwappiness = nil
+	}
 
 	// simpleNetworkConfig is a networkConfig with only 1 network.
 	// see: https://github.com/docker/docker/issues/29265


### PR DESCRIPTION
This is essentially a duplicate of https://github.com/containrrr/watchtower/pull/2072 . It allows for an optional env setting that makes watchtower compatible with podman.
Since your repo is more well-maintained than the original repo, and this a change I need -- I'm suggesting a PR here.